### PR TITLE
Dpi awareness support

### DIFF
--- a/DpiTest/App.xaml
+++ b/DpiTest/App.xaml
@@ -1,0 +1,8 @@
+﻿<Application x:Class="DpiTest.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/DpiTest/App.xaml.cs
+++ b/DpiTest/App.xaml.cs
@@ -1,0 +1,6 @@
+﻿namespace DpiTest
+{
+    public partial class App 
+    {
+    }
+}

--- a/DpiTest/DpiTest.csproj
+++ b/DpiTest/DpiTest.csproj
@@ -1,0 +1,87 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E5CE9242-5470-48D5-8AA2-04707A57D4EC}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>DpiTest</RootNamespace>
+    <AssemblyName>DpiTest</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <WarningLevel>4</WarningLevel>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xaml">
+      <RequiredTargetFramework>4.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="WindowsBase" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </ApplicationDefinition>
+    <Page Include="MainWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Compile Include="App.xaml.cs">
+      <DependentUpon>App.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="MainWindow.xaml.cs">
+      <DependentUpon>MainWindow.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.manifest" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\WpfScreenHelper\WpfScreenHelper.csproj">
+      <Project>{8346eb2e-bfbb-4d63-b974-352a4d8c07f1}</Project>
+      <Name>WpfScreenHelper</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/DpiTest/MainWindow.xaml
+++ b/DpiTest/MainWindow.xaml
@@ -1,0 +1,30 @@
+﻿<Window x:Class="DpiTest.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="MainWindow" Name="Wnd" 
+        Height="400" Width="700" SnapsToDevicePixels="True" WindowStyle="None" ResizeMode="NoResize"
+        Loaded="MainWindow_OnLoaded" MouseLeftButtonDown="MainWindow_OnMouseLeftButtonDown">
+    <Grid>
+        <Button Width="200" Height="50" Content="Position Center" Margin="5" Click="ButtonCenter_OnClick"/>
+        <Button Width="200" Height="50" Content="Position Left" Margin="5" HorizontalAlignment="Left" VerticalAlignment="Center" Click="ButtonLeft_OnClick"/>
+        <Button Width="200" Height="50" Content="Position Right" Margin="5" HorizontalAlignment="Right" VerticalAlignment="Center" Click="ButtonRight_OnClick"/>
+        <Button Width="200" Height="50" Content="Position Top" Margin="5" HorizontalAlignment="Center" VerticalAlignment="Top" Click="ButtonTop_OnClick"/>
+        <Button Width="200" Height="50" Content="Position Bottom" Margin="5" HorizontalAlignment="Center" VerticalAlignment="Bottom" Click="ButtonBottom_OnClick"/>
+        <Button Width="200" Height="50" Content="Position TopLeft" Margin="5" HorizontalAlignment="Left" VerticalAlignment="Top" Click="ButtonTopLeft_OnClick"/>
+        <Button Width="200" Height="50" Content="Position TopRight" Margin="5" HorizontalAlignment="Right" VerticalAlignment="Top" Click="ButtonTopRight_OnClick"/>
+        <Button Width="200" Height="50" Content="Position BottomRight" Margin="5" HorizontalAlignment="Right" VerticalAlignment="Bottom" Click="ButtonBottomRight_OnClick"/>
+        <Button Width="200" Height="50" Content="Position BottomLeft" Margin="5" HorizontalAlignment="Left" VerticalAlignment="Bottom" Click="ButtonBottomLeft_OnClick"/>
+
+        <StackPanel HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="5,0,0,70">
+            <TextBlock Text="{Binding ElementName=Wnd, Path=Width, StringFormat='Width: {0}'}"/>
+            <TextBlock Text="{Binding ElementName=Wnd, Path=Height, StringFormat='Height: {0}'}"/>
+            <TextBlock Text="{Binding ElementName=Wnd, Path=Left, StringFormat='Left: {0}'}"/>
+            <TextBlock Text="{Binding ElementName=Wnd, Path=Top, StringFormat='Top: {0}'}"/>
+        </StackPanel>
+
+        <ComboBox Name="Monitors" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="5"/>
+    </Grid>
+</Window>

--- a/DpiTest/MainWindow.xaml.cs
+++ b/DpiTest/MainWindow.xaml.cs
@@ -1,0 +1,145 @@
+﻿using System.Linq;
+using System.Windows;
+using System.Windows.Input;
+using WpfScreenHelper;
+
+namespace DpiTest
+{
+    public partial class MainWindow
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void MainWindow_OnLoaded(object sender, RoutedEventArgs e)
+        {
+            foreach (var screen in Screen.AllScreens)
+            {
+                Monitors.Items.Add(screen.DeviceName);
+            }
+
+            Monitors.SelectedIndex = 0;
+        }
+
+        private void ButtonCenter_OnClick(object sender, RoutedEventArgs e)
+        {
+            SetWindowPosition(this, WindowPositions.Center,
+                Screen.AllScreens.ElementAt(Monitors.SelectedIndex).Bounds);
+        }
+
+        private void ButtonLeft_OnClick(object sender, RoutedEventArgs e)
+        {
+            SetWindowPosition(this, WindowPositions.Left,
+                Screen.AllScreens.ElementAt(Monitors.SelectedIndex).Bounds);
+        }
+
+        private void ButtonRight_OnClick(object sender, RoutedEventArgs e)
+        {
+            SetWindowPosition(this, WindowPositions.Right,
+                Screen.AllScreens.ElementAt(Monitors.SelectedIndex).Bounds);
+        }
+
+        private void ButtonTop_OnClick(object sender, RoutedEventArgs e)
+        {
+            SetWindowPosition(this, WindowPositions.Top,
+                Screen.AllScreens.ElementAt(Monitors.SelectedIndex).Bounds);
+        }
+
+        private void ButtonBottom_OnClick(object sender, RoutedEventArgs e)
+        {
+            SetWindowPosition(this, WindowPositions.Bottom,
+                Screen.AllScreens.ElementAt(Monitors.SelectedIndex).Bounds);
+        }
+
+        private void ButtonTopLeft_OnClick(object sender, RoutedEventArgs e)
+        {
+            SetWindowPosition(this, WindowPositions.TopLeft,
+                Screen.AllScreens.ElementAt(Monitors.SelectedIndex).Bounds);
+        }
+
+        private void ButtonTopRight_OnClick(object sender, RoutedEventArgs e)
+        {
+            SetWindowPosition(this, WindowPositions.TopRight,
+                Screen.AllScreens.ElementAt(Monitors.SelectedIndex).Bounds);
+        }
+
+        private void ButtonBottomRight_OnClick(object sender, RoutedEventArgs e)
+        {
+            SetWindowPosition(this, WindowPositions.BottomRight,
+                Screen.AllScreens.ElementAt(Monitors.SelectedIndex).Bounds);
+        }
+
+        private void ButtonBottomLeft_OnClick(object sender, RoutedEventArgs e)
+        {
+            SetWindowPosition(this, WindowPositions.BottomLeft,
+                Screen.AllScreens.ElementAt(Monitors.SelectedIndex).Bounds);
+        }
+        private void MainWindow_OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            DragMove();
+        }
+
+        private enum WindowPositions
+        {
+            Center,
+            Left,
+            Top,
+            Right,
+            Bottom,
+            TopLeft,
+            TopRight,
+            BottomRight,
+            BottomLeft
+        }
+
+        private static void SetWindowPosition(Window wnd, WindowPositions pos, Rect bounds)
+        {
+            var x = 0.0d;
+            var y = 0.0d;
+
+            switch (pos)
+            {
+                case WindowPositions.Center:
+                    x = bounds.X + (bounds.Width - wnd.Width) / 2.0;
+                    y = bounds.Y + (bounds.Height - wnd.Height) / 2.0;
+                    break;
+                case WindowPositions.Left:
+                    x = bounds.X;
+                    y = bounds.Y + (bounds.Height - wnd.Height) / 2.0;
+                    break;
+                case WindowPositions.Top:
+                    x = bounds.X + (bounds.Width - wnd.Width) / 2.0;
+                    y = bounds.Y;
+                    break;
+                case WindowPositions.Right:
+                    x = bounds.X + (bounds.Width - wnd.Width);
+                    y = bounds.Y + (bounds.Height - wnd.Height) / 2.0;
+                    break;
+                case WindowPositions.Bottom:
+                    x = bounds.X + (bounds.Width - wnd.Width) / 2.0;
+                    y = bounds.Y + (bounds.Height - wnd.Height);
+                    break;
+                case WindowPositions.TopLeft:
+                    x = bounds.X;
+                    y = bounds.Y;
+                    break;
+                case WindowPositions.TopRight:
+                    x = bounds.X + (bounds.Width - wnd.Width);
+                    y = bounds.Y;
+                    break;
+                case WindowPositions.BottomRight:
+                    x = bounds.X + (bounds.Width - wnd.Width);
+                    y = bounds.Y + (bounds.Height - wnd.Height);
+                    break;
+                case WindowPositions.BottomLeft:
+                    x = bounds.X;
+                    y = bounds.Y + (bounds.Height - wnd.Height);
+                    break;
+            }
+
+            wnd.Left = x;
+            wnd.Top = y;
+        }
+    }
+}

--- a/DpiTest/app.manifest
+++ b/DpiTest/app.manifest
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<asmv1:assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv1="urn:schemas-microsoft-com:asm.v1" xmlns:asmv2="urn:schemas-microsoft-com:asm.v2" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+
+  <asmv3:application>
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+      <!-- Per Monitor V1 [OS >= Windows 8.1] 
+         Values: False, True, Per-monitor, True/PM -->
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+      <!-- Per Monitor V1 [OS >= Windows 10 Anniversary Update (1607, 10.0.14393, Redstone 1)]
+         Values: Unaware, System, PerMonitor -->
+      <!-- Per Monitor V2 [OS >= Windows 10 Creators Update (1703, 10.0.15063, Redstone 2)]
+         Value: PerMonitorV2 -->
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+
+</asmv1:assembly>

--- a/WpfScreenHelper.sln
+++ b/WpfScreenHelper.sln
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DpiTest", "DpiTest\DpiTest.csproj", "{E5CE9242-5470-48D5-8AA2-04707A57D4EC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,6 +26,10 @@ Global
 		{8346EB2E-BFBB-4D63-B974-352A4D8C07F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8346EB2E-BFBB-4D63-B974-352A4D8C07F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8346EB2E-BFBB-4D63-B974-352A4D8C07F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E5CE9242-5470-48D5-8AA2-04707A57D4EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5CE9242-5470-48D5-8AA2-04707A57D4EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5CE9242-5470-48D5-8AA2-04707A57D4EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5CE9242-5470-48D5-8AA2-04707A57D4EC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/WpfScreenHelper/ExternDll.cs
+++ b/src/WpfScreenHelper/ExternDll.cs
@@ -4,5 +4,6 @@
     {
         public const string User32 = "user32.dll";
         public const string Gdi32 = "gdi32.dll";
+        public const string Shcore = "shcore.dll";
     }
 }

--- a/src/WpfScreenHelper/MouseHelper.cs
+++ b/src/WpfScreenHelper/MouseHelper.cs
@@ -8,9 +8,21 @@ namespace WpfScreenHelper
         {
             get
             {
-                NativeMethods.POINT pt = new NativeMethods.POINT();
+                var pt = new NativeMethods.POINT();
                 NativeMethods.GetCursorPos(pt);
-                return new Point(pt.x, pt.y);
+                var point = new Point(pt.x, pt.y);
+
+                if (Screen.PerMonitorDpiAware)
+                {
+                    var pointStruct = new NativeMethods.POINTSTRUCT((int) point.X, (int) point.Y);
+
+                    var screen = Screen.FromPoint(pointStruct);
+
+                    if (!screen.ScaleFactor.Equals(1.0))
+                        point = new Point(pt.x / screen.ScaleFactor, pt.y / screen.ScaleFactor);
+                }
+
+                return point;
             }
         }
     }

--- a/src/WpfScreenHelper/NativeMethods.cs
+++ b/src/WpfScreenHelper/NativeMethods.cs
@@ -151,9 +151,10 @@ namespace WpfScreenHelper
         public class MONITORINFOEX
         {
             internal int cbSize = Marshal.SizeOf(typeof(MONITORINFOEX));
-            internal int dwFlags = 0;
+
             internal RECT rcMonitor = new RECT();
             internal RECT rcWork = new RECT();
+            internal int dwFlags = 0;
 
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
             internal char[] szDevice = new char[32];

--- a/src/WpfScreenHelper/Screen.cs
+++ b/src/WpfScreenHelper/Screen.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows;
@@ -8,7 +9,7 @@ using System.Windows;
 namespace WpfScreenHelper
 {
     /// <summary>
-    /// Represents a display device or multiple display devices on a single system.
+    ///     Represents a display device or multiple display devices on a single system.
     /// </summary>
     public class Screen
     {
@@ -17,21 +18,23 @@ namespace WpfScreenHelper
         // http://msdn.microsoft.com/en-us/library/windows/desktop/dd145072.aspx
         // http://msdn.microsoft.com/en-us/library/windows/desktop/dd183314.aspx
 
-        private readonly IntPtr hmonitor;
-
         // This identifier is just for us, so that we don't try to call the multimon
         // functions if we just need the primary monitor... this is safer for
         // non-multimon OSes.
-        private const int PRIMARY_MONITOR = unchecked((int)0xBAADF00D);
+        private const int PRIMARY_MONITOR = unchecked((int) 0xBAADF00D);
 
         private const int MONITORINFOF_PRIMARY = 0x00000001;
         private const int MONITOR_DEFAULTTONEAREST = 0x00000002;
 
-        private static bool multiMonitorSupport;
+        private static readonly bool multiMonitorSupport;
+        internal static readonly bool PerMonitorDpiAware;
+
+        private readonly IntPtr hmonitor;
 
         static Screen()
         {
-            multiMonitorSupport = NativeMethods.GetSystemMetrics(NativeMethods.SM_CMONITORS) != 0;
+            multiMonitorSupport = NativeMethods.GetSystemMetrics(NativeMethods.SystemMetric.SM_CMONITORS) != 0;
+            PerMonitorDpiAware = IsPerMonitorAware();
         }
 
         private Screen(IntPtr monitor)
@@ -41,32 +44,40 @@ namespace WpfScreenHelper
 
         private Screen(IntPtr monitor, IntPtr hdc)
         {
-            if (!multiMonitorSupport || monitor == (IntPtr)PRIMARY_MONITOR)
+            if (PerMonitorDpiAware)
             {
-                this.Bounds = SystemInformation.VirtualScreen;
-                this.Primary = true;
-                this.DeviceName = "DISPLAY";
+                NativeMethods.GetDpiForMonitor(monitor, NativeMethods.DpiType.EFFECTIVE, out var dpiX, out _);
+
+                ScaleFactor = dpiX / 96.0;
+            }
+
+            if (!multiMonitorSupport || monitor == (IntPtr) PRIMARY_MONITOR)
+            {
+                var size = new Size(NativeMethods.GetSystemMetrics(NativeMethods.SystemMetric.SM_CXSCREEN),
+                    NativeMethods.GetSystemMetrics(NativeMethods.SystemMetric.SM_CYSCREEN));
+
+                PixelBounds = new Rect(0, 0, size.Width, size.Height);
+                Primary = true;
+                DeviceName = "DISPLAY";
             }
             else
             {
                 var info = new NativeMethods.MONITORINFOEX();
 
                 NativeMethods.GetMonitorInfo(new HandleRef(null, monitor), info);
-
-                this.Bounds = new Rect(
+                PixelBounds = new Rect(
                     info.rcMonitor.left, info.rcMonitor.top,
                     info.rcMonitor.right - info.rcMonitor.left,
                     info.rcMonitor.bottom - info.rcMonitor.top);
-
-                this.Primary = ((info.dwFlags & MONITORINFOF_PRIMARY) != 0);
-
-                this.DeviceName = new string(info.szDevice).TrimEnd((char)0);
+                Primary = (info.dwFlags & MONITORINFOF_PRIMARY) != 0;
+                DeviceName = new string(info.szDevice).TrimEnd((char) 0);
             }
+
             hmonitor = monitor;
         }
 
         /// <summary>
-        /// Gets an array of all displays on the system.
+        ///     Gets an array of all displays on the system.
         /// </summary>
         /// <returns>An enumerable of type Screen, containing all displays on the system.</returns>
         public static IEnumerable<Screen> AllScreens
@@ -78,138 +89,196 @@ namespace WpfScreenHelper
                     var closure = new MonitorEnumCallback();
                     var proc = new NativeMethods.MonitorEnumProc(closure.Callback);
                     NativeMethods.EnumDisplayMonitors(NativeMethods.NullHandleRef, null, proc, IntPtr.Zero);
-                    if (closure.Screens.Count > 0)
-                    {
-                        return closure.Screens.Cast<Screen>();
-                    }
+                    if (closure.Screens.Count > 0) return closure.Screens.Cast<Screen>();
                 }
-                return new[] { new Screen((IntPtr)PRIMARY_MONITOR) };
+
+                return new[] {new Screen((IntPtr) PRIMARY_MONITOR)};
             }
         }
 
         /// <summary>
-        /// Gets the bounds of the display.
-        /// </summary>
-        /// <returns>A <see cref="T:System.Windows.Rect" />, representing the bounds of the display.</returns>
-        public Rect Bounds { get; private set; }
-
-        /// <summary>
-        /// Gets the device name associated with a display.
-        /// </summary>
-        /// <returns>The device name associated with a display.</returns>
-        public string DeviceName { get; private set; }
-
-        /// <summary>
-        /// Gets a value indicating whether a particular display is the primary device.
-        /// </summary>
-        /// <returns>true if this display is primary; otherwise, false.</returns>
-        public bool Primary { get; private set; }
-
-        /// <summary>
-        /// Gets the primary display.
+        ///     Gets the primary display.
         /// </summary>
         /// <returns>The primary display.</returns>
         public static Screen PrimaryScreen
         {
             get
             {
-                if (multiMonitorSupport)
-                {
-                    return AllScreens.FirstOrDefault(t => t.Primary);
-                }
-                return new Screen((IntPtr)PRIMARY_MONITOR);
+                return multiMonitorSupport
+                    ? AllScreens.FirstOrDefault(t => t.Primary)
+                    : new Screen((IntPtr) PRIMARY_MONITOR);
             }
         }
 
         /// <summary>
-        /// Gets the working area of the display. The working area is the desktop area of the display, excluding taskbars, docked windows, and docked tool bars.
+        ///     Gets the bounds of the display in pixels.
         /// </summary>
-        /// <returns>A <see cref="T:System.Windows.Rect" />, representing the working area of the display.</returns>
+        /// <returns>A <see cref="T:System.Windows.Rect" />, representing the bounds of the display in pixels.</returns>
+        public Rect PixelBounds { get; }
+
+        /// <summary>
+        ///     Gets the bounds of the display in units.
+        /// </summary>
+        /// <returns>A <see cref="T:System.Windows.Rect" />, representing the bounds of the display in units.</returns>
+        public Rect Bounds => ScaleFactor.Equals(1.0)
+            ? PixelBounds
+            : new Rect(PixelBounds.X / ScaleFactor, PixelBounds.Y / ScaleFactor, PixelBounds.Width / ScaleFactor,
+                PixelBounds.Height / ScaleFactor);
+
+        /// <summary>
+        ///     Gets the device name associated with a display.
+        /// </summary>
+        /// <returns>The device name associated with a display.</returns>
+        public string DeviceName { get; }
+
+        /// <summary>
+        ///     Gets a value indicating whether a particular display is the primary device.
+        /// </summary>
+        /// <returns>true if this display is primary; otherwise, false.</returns>
+        public bool Primary { get; }
+
+        /// <summary>
+        ///     Gets the scale factor of the display.
+        /// </summary>
+        /// <returns>The scale factor of the display.</returns>
+        public double ScaleFactor { get; } = 1.0;
+
+        /// <summary>
+        ///     Gets the working area of the display. The working area is the desktop area of the display, excluding taskbars,
+        ///     docked windows, and docked tool bars in units.
+        /// </summary>
+        /// <returns>A <see cref="T:System.Windows.Rect" />, representing the working area of the display in units.</returns>
         public Rect WorkingArea
         {
             get
             {
-                if (!multiMonitorSupport || hmonitor == (IntPtr)PRIMARY_MONITOR)
+                Rect workingArea;
+
+                if (!multiMonitorSupport || hmonitor == (IntPtr) PRIMARY_MONITOR)
                 {
-                    return SystemInformation.WorkingArea;
+                    var rc = new NativeMethods.RECT();
+                    NativeMethods.SystemParametersInfo(NativeMethods.SPI_GETWORKAREA, 0, ref rc, 0);
+
+                    workingArea = ScaleFactor.Equals(1.0)
+                        ? new Rect(rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top)
+                        : new Rect(rc.left / ScaleFactor, rc.top / ScaleFactor, (rc.right - rc.left) / ScaleFactor,
+                            (rc.bottom - rc.top) / ScaleFactor);
                 }
-                var info = new NativeMethods.MONITORINFOEX();
-                NativeMethods.GetMonitorInfo(new HandleRef(null, hmonitor), info);
-                return new Rect(
-                    info.rcWork.left, info.rcWork.top,
-                    info.rcWork.right - info.rcWork.left,
-                    info.rcWork.bottom - info.rcWork.top);
+                else
+                {
+                    var info = new NativeMethods.MONITORINFOEX();
+                    NativeMethods.GetMonitorInfo(new HandleRef(null, hmonitor), info);
+
+                    workingArea = ScaleFactor.Equals(1.0)
+                        ? new Rect(info.rcWork.left, info.rcWork.top, info.rcWork.right - info.rcWork.left,
+                            info.rcWork.bottom - info.rcWork.top)
+                        : new Rect(info.rcWork.left / ScaleFactor, info.rcWork.top / ScaleFactor,
+                            (info.rcWork.right - info.rcWork.left) / ScaleFactor,
+                            (info.rcWork.bottom - info.rcWork.top) / ScaleFactor);
+                }
+
+                return workingArea;
             }
         }
 
         /// <summary>
-        /// Retrieves a Screen for the display that contains the largest portion of the specified control.
+        ///     Retrieves a Screen for the display that contains the largest portion of the specified control.
         /// </summary>
         /// <param name="hwnd">The window handle for which to retrieve the Screen.</param>
-        /// <returns>A Screen for the display that contains the largest region of the object. In multiple display environments where no display contains any portion of the specified window, the display closest to the object is returned.</returns>
+        /// <returns>
+        ///     A Screen for the display that contains the largest region of the object. In multiple display environments
+        ///     where no display contains any portion of the specified window, the display closest to the object is returned.
+        /// </returns>
         public static Screen FromHandle(IntPtr hwnd)
         {
-            if (multiMonitorSupport)
-            {
-                return new Screen(NativeMethods.MonitorFromWindow(new HandleRef(null, hwnd), 2));
-            }
-            return new Screen((IntPtr)PRIMARY_MONITOR);
+            if (multiMonitorSupport) return new Screen(NativeMethods.MonitorFromWindow(new HandleRef(null, hwnd), 2));
+
+            return new Screen((IntPtr) PRIMARY_MONITOR);
         }
 
         /// <summary>
-        /// Retrieves a Screen for the display that contains the specified point.
+        ///     Retrieves a Screen for the display that contains the specified point.
         /// </summary>
         /// <param name="point">A <see cref="T:System.Windows.Point" /> that specifies the location for which to retrieve a Screen.</param>
-        /// <returns>A Screen for the display that contains the point. In multiple display environments where no display contains the point, the display closest to the specified point is returned.</returns>
+        /// <returns>
+        ///     A Screen for the display that contains the point. In multiple display environments where no display contains
+        ///     the point, the display closest to the specified point is returned.
+        /// </returns>
         public static Screen FromPoint(Point point)
         {
             if (multiMonitorSupport)
             {
-                var pt = new NativeMethods.POINTSTRUCT((int)point.X, (int)point.Y);
+                var pt = new NativeMethods.POINTSTRUCT((int) point.X, (int) point.Y);
                 return new Screen(NativeMethods.MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST));
             }
-            return new Screen((IntPtr)PRIMARY_MONITOR);
+
+            return new Screen((IntPtr) PRIMARY_MONITOR);
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the specified object is equal to this Screen.
+        ///     Retrieves a Screen for the display that contains the specified point.
+        /// </summary>
+        /// <param name="point">
+        ///     A <see cref="T:NativeMethods.POINTSTRUCT" /> that specifies the location for which to retrieve a
+        ///     Screen.
+        /// </param>
+        /// <returns>
+        ///     A Screen for the display that contains the point. In multiple display environments where no display contains
+        ///     the point, the display closest to the specified point is returned.
+        /// </returns>
+        internal static Screen FromPoint(NativeMethods.POINTSTRUCT point)
+        {
+            if (multiMonitorSupport) return new Screen(NativeMethods.MonitorFromPoint(point, MONITOR_DEFAULTTONEAREST));
+
+            return new Screen((IntPtr) PRIMARY_MONITOR);
+        }
+
+        /// <summary>
+        ///     Retrieves current process dpi awareness.
+        /// </summary>
+        /// <returns>true if current process dpi awareness equals per monitor dpi aware.</returns>
+        private static bool IsPerMonitorAware()
+        {
+            NativeMethods.GetProcessDpiAwareness(Process.GetCurrentProcess().Handle, out var value);
+
+            return value == NativeMethods.PROCESS_DPI_AWARENESS.PROCESS_PER_MONITOR_DPI_AWARE;
+        }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether the specified object is equal to this Screen.
         /// </summary>
         /// <param name="obj">The object to compare to this Screen.</param>
         /// <returns>true if the specified object is equal to this Screen; otherwise, false.</returns>
         public override bool Equals(object obj)
         {
-            var monitor = obj as Screen;
-            if (monitor != null)
-            {
+            if (obj is Screen monitor)
                 if (hmonitor == monitor.hmonitor)
-                {
                     return true;
-                }
-            }
+
             return false;
         }
 
         /// <summary>
-        /// Computes and retrieves a hash code for an object.
+        ///     Computes and retrieves a hash code for an object.
         /// </summary>
         /// <returns>A hash code for an object.</returns>
         public override int GetHashCode()
         {
-            return (int)hmonitor;
+            return (int) hmonitor;
         }
 
         private class MonitorEnumCallback
         {
-            public ArrayList Screens { get; private set; }
-
             public MonitorEnumCallback()
             {
-                this.Screens = new ArrayList();
+                Screens = new ArrayList();
             }
+
+            public ArrayList Screens { get; }
 
             public bool Callback(IntPtr monitor, IntPtr hdc, IntPtr lprcMonitor, IntPtr lparam)
             {
-                this.Screens.Add(new Screen(monitor, hdc));
+                Screens.Add(new Screen(monitor, hdc));
                 return true;
             }
         }

--- a/src/WpfScreenHelper/SystemInformation.cs
+++ b/src/WpfScreenHelper/SystemInformation.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using System.Windows;
 
 namespace WpfScreenHelper
@@ -5,34 +7,49 @@ namespace WpfScreenHelper
     public static class SystemInformation
     {
         /// <summary>
-        /// Gets the bounds of the virtual screen.
+        ///     Gets the bounds of the virtual screen in units.
         /// </summary>
-        /// <returns>A <see cref="T:System.Windows.Rect" /> that specifies the bounding rectangle of the entire virtual screen.</returns>
+        /// <returns>
+        ///     A <see cref="T:System.Windows.Rect" /> that specifies the bounding rectangle of the entire virtual screen in
+        ///     units.
+        /// </returns>
         public static Rect VirtualScreen
         {
             get
             {
-                var size = new Size(NativeMethods.GetSystemMetrics(NativeMethods.SM_CXSCREEN),
-                                    NativeMethods.GetSystemMetrics(NativeMethods.SM_CYSCREEN));
-                return new Rect(0, 0, size.Width, size.Height);
+                if (Screen.PerMonitorDpiAware)
+                {
+                    var values = Screen.AllScreens.Aggregate(
+                        new
+                        {
+                            xMin = 0.0,
+                            yMin = 0.0,
+                            xMax = 0.0,
+                            yMax = 0.0
+                        },
+                        (accumulator, s) => new
+                        {
+                            xMin = Math.Min(s.Bounds.X, accumulator.xMin),
+                            yMin = Math.Min(s.Bounds.Y, accumulator.yMin),
+                            xMax = Math.Max(s.Bounds.Right, accumulator.xMax),
+                            yMax = Math.Max(s.Bounds.Bottom, accumulator.yMax)
+                        });
+
+                    return new Rect(values.xMin, values.yMin, values.xMax - values.xMin, values.yMax - values.yMin);
+                }
+
+                var size = new Size(NativeMethods.GetSystemMetrics(NativeMethods.SystemMetric.SM_CXVIRTUALSCREEN),
+                    NativeMethods.GetSystemMetrics(NativeMethods.SystemMetric.SM_CYVIRTUALSCREEN));
+                var location = new Point(NativeMethods.GetSystemMetrics(NativeMethods.SystemMetric.SM_XVIRTUALSCREEN),
+                    NativeMethods.GetSystemMetrics(NativeMethods.SystemMetric.SM_YVIRTUALSCREEN));
+                return new Rect(location.X, location.Y, size.Width, size.Height);
             }
         }
 
         /// <summary>
-        /// Gets the size, in pixels, of the working area of the screen.
+        ///     Gets the size, in pixels, of the working area of the screen.
         /// </summary>
         /// <returns>A <see cref="T:System.Windows.Rect" /> that represents the size, in pixels, of the working area of the screen.</returns>
-        public static Rect WorkingArea
-        {
-            get
-            {
-                NativeMethods.RECT rc = new NativeMethods.RECT();
-                NativeMethods.SystemParametersInfo(NativeMethods.SPI_GETWORKAREA, 0, ref rc, 0);
-                return new Rect(rc.left,
-                                rc.top,
-                                rc.right - rc.left,
-                                rc.bottom - rc.top);
-            }
-        }
+        public static Rect WorkingArea => Screen.PrimaryScreen.WorkingArea;
     }
 }


### PR DESCRIPTION
Greetings, @micdenny.

First of all, thanks for awesome library!
Recently I was working at window positioning problem in wpf for one of my projects. Problem is that in per monitor dpi awareness mode you should take in account scale of your screens since wpf works with units not pixels. That's why I added few calls to get both screen bounds and scale in one go. You can check result in test project if you have 2 or more monitors.