### PR TITLE
Compatibility .Net6.0-windows

### DIFF
--- a/src/WpfScreenHelper/WpfScreenHelper.csproj
+++ b/src/WpfScreenHelper/WpfScreenHelper.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net40;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net40;netcoreapp3.1;net6.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyName>WpfScreenHelper</AssemblyName>
@@ -14,7 +14,8 @@
     <PackageTags>WPF Screen Monitor Display Helper</PackageTags>
     <RepositoryUrl>https://github.com/micdenny/WpfScreenHelper</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
+    <FileVersion>2023.2.21.3</FileVersion>
   </PropertyGroup>
 
   <Target Name="CopyPackage" AfterTargets="Pack">

--- a/test/WpfScreenHelper.DpiTestWpfApp/WpfScreenHelper.DpiTestWpfApp.csproj
+++ b/test/WpfScreenHelper.DpiTestWpfApp/WpfScreenHelper.DpiTestWpfApp.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <FileVersion>2023.2.21.1</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add Compatibility for .Net6.0-windows because the actual nuget version is not available for .net6.0